### PR TITLE
gradle-javacpp-android: update gradle and javacpp version

### DIFF
--- a/gradle-javacpp-android/README.md
+++ b/gradle-javacpp-android/README.md
@@ -6,6 +6,14 @@ It was created by following the instructions available at:
 Along with the `NativeLibrary.h` example file from:
   * https://github.com/bytedeco/javacpp#accessing-native-apis
 
+## Instructions
+To generate jni stuffs, run:
+```shell
+./gradlew :app:javacppCompileJavaDebug  && ./gradlew :app:javacppBuildParserDebug && ./gradlew :app:javacppBuildCompilerDebug
+```
+
+Then simply press run button in Android Studio.
+
 ----
 Author: [Samuel Audet](https://github.com/saudet/)  
 Sponsor: [Iuliu Horga](https://github.com/iuliuh) via [xs:code](https://xscode.com/)

--- a/gradle-javacpp-android/app/build.gradle
+++ b/gradle-javacpp-android/app/build.gradle
@@ -36,8 +36,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 

--- a/gradle-javacpp-android/app/build.gradle
+++ b/gradle-javacpp-android/app/build.gradle
@@ -51,13 +51,13 @@ android.applicationVariants.configureEach { variant ->
         include 'com/example/myapplication/NativeLibraryConfig.java'
         source = javaCompile.source
         classpath = javaCompile.classpath
-        destinationDirectory.set(file(javaCompile.destinationDir))
+        destinationDirectory.set(javaCompile.destinationDirectory)
     }
 
     // Parses NativeLibrary.h and outputs NativeLibrary.java
     tasks.register("javacppBuildParser$variantName", org.bytedeco.gradle.javacpp.BuildTask) {
         dependsOn "javacppCompileJava$variantName"
-        classPath = [javaCompile.destinationDir]
+        classPath = [file(javaCompile.destinationDirectory)]
         includePath =  ["$projectDir/src/main/cpp/"]
         classOrPackageNames = ['com.example.myapplication.NativeLibraryConfig']
         outputDirectory = file("$projectDir/src/main/java/")
@@ -69,7 +69,7 @@ android.applicationVariants.configureEach { variant ->
     // Generates jnijavacpp.cpp and jniNativeLibrary.cpp
     tasks.register("javacppBuildCompiler$variantName", org.bytedeco.gradle.javacpp.BuildTask) {
         dependsOn javaCompile
-        classPath = [javaCompile.destinationDir]
+        classPath = [file(javaCompile.destinationDirectory)]
         classOrPackageNames = ['com.example.myapplication.NativeLibrary']
         compile = false
         deleteJniFiles = false

--- a/gradle-javacpp-android/app/build.gradle
+++ b/gradle-javacpp-android/app/build.gradle
@@ -1,15 +1,16 @@
 plugins {
     id 'com.android.application'
-    id 'org.bytedeco.gradle-javacpp-build' version '1.5.4'
+    id 'org.bytedeco.gradle-javacpp-build' version '1.5.10'
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    namespace "com.example.myapplication"
+    compileSdk 34
+    buildToolsVersion = "34.0.0"
 
     defaultConfig {
         applicationId "com.example.myapplication"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"
@@ -31,7 +32,7 @@ android {
     externalNativeBuild {
         cmake {
             path "src/main/cpp/CMakeLists.txt"
-            version "3.10.2"
+            version "3.22.1"
         }
     }
     compileOptions {
@@ -40,21 +41,21 @@ android {
     }
 }
 
-android.applicationVariants.all { variant ->
+android.applicationVariants.configureEach { variant ->
     def variantName = variant.name.capitalize() // either "Debug" or "Release"
-    def javaCompile = project.tasks.getByName("compile${variantName}JavaWithJavac")
-    def generateJson = project.tasks.getByName("generateJsonModel$variantName")
+    def javaCompile = project.tasks.named("compile${variantName}JavaWithJavac").get()
+    def generateJson = project.tasks.named("generateJsonModel$variantName").get()
 
     // Compiles NativeLibraryConfig.java
-    task "javacppCompileJava$variantName"(type: JavaCompile) {
+    tasks.register("javacppCompileJava$variantName", JavaCompile) {
         include 'com/example/myapplication/NativeLibraryConfig.java'
         source = javaCompile.source
         classpath = javaCompile.classpath
-        destinationDir = javaCompile.destinationDir
+        destinationDirectory.set(file(javaCompile.destinationDir))
     }
 
     // Parses NativeLibrary.h and outputs NativeLibrary.java
-    task "javacppBuildParser$variantName"(type: org.bytedeco.gradle.javacpp.BuildTask) {
+    tasks.register("javacppBuildParser$variantName", org.bytedeco.gradle.javacpp.BuildTask) {
         dependsOn "javacppCompileJava$variantName"
         classPath = [javaCompile.destinationDir]
         includePath =  ["$projectDir/src/main/cpp/"]
@@ -66,7 +67,7 @@ android.applicationVariants.all { variant ->
     javaCompile.dependsOn "javacppBuildParser$variantName"
 
     // Generates jnijavacpp.cpp and jniNativeLibrary.cpp
-    task "javacppBuildCompiler$variantName"(type: org.bytedeco.gradle.javacpp.BuildTask) {
+    tasks.register("javacppBuildCompiler$variantName", org.bytedeco.gradle.javacpp.BuildTask) {
         dependsOn javaCompile
         classPath = [javaCompile.destinationDir]
         classOrPackageNames = ['com.example.myapplication.NativeLibrary']
@@ -80,11 +81,11 @@ android.applicationVariants.all { variant ->
 }
 
 dependencies {
-    implementation 'org.bytedeco:javacpp:1.5.4'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.google.android.material:material:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation 'org.bytedeco:javacpp:1.5.10'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/gradle-javacpp-android/app/build.gradle
+++ b/gradle-javacpp-android/app/build.gradle
@@ -11,7 +11,7 @@ android {
     defaultConfig {
         applicationId "com.example.myapplication"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 
@@ -41,6 +41,8 @@ android {
     }
 }
 
+// For library variant, please use android.libraryVariants.
+// (see in plugins if you are using com.android.application or com.android.library)
 android.applicationVariants.configureEach { variant ->
     def variantName = variant.name.capitalize() // either "Debug" or "Release"
     def javaCompile = project.tasks.named("compile${variantName}JavaWithJavac").get()

--- a/gradle-javacpp-android/app/src/main/AndroidManifest.xml
+++ b/gradle-javacpp-android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.myapplication">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/gradle-javacpp-android/app/src/main/AndroidManifest.xml
+++ b/gradle-javacpp-android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MyApplication">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/gradle-javacpp-android/build.gradle
+++ b/gradle-javacpp-android/build.gradle
@@ -2,10 +2,10 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.1"
+        classpath "com.android.tools.build:gradle:8.3.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,10 +15,10 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register('clean', Delete) {
+    delete rootProject.layout.buildDirectory
 }

--- a/gradle-javacpp-android/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-javacpp-android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip


### PR DESCRIPTION

Updating gradle version and applying suggestions from Android Studio related to this change.
Updating javacpp and javacpp-plugin to 1.5.10.

For this to work you need the JDK 17 to be set in settings -> gradle.
